### PR TITLE
Add a menu item to toggle menu bar autohiding on non-OS X platforms.

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -193,10 +193,31 @@ app.toggleTray = function() {
     }
 };
 
+function hideMenuBar(window) {
+    window.setAutoHideMenuBar(true);
+    window.setMenuBarVisibility(false);
+}
+
+function showMenuBar(window) {
+    window.setAutoHideMenuBar(false);
+    window.setMenuBarVisibility(true);
+}
+
+app.toggleMenuBar = function (window) {
+    if (config.get('menu-bar')) {
+        return showMenuBar(window);
+    } else {
+        return hideMenuBar(window);
+    }
+};
+
 app.on('ready', function() {
   menu = Menu.setup(host);
   openMainWindow();
   if (config.get('tray') && process.platform != 'darwin') {
       setupTray();
+  }
+  if (config.get('menu-bar') === false && process.platform != 'darwin') {
+      hideMenuBar(mainWindow);
   }
 });

--- a/app/menu.js
+++ b/app/menu.js
@@ -293,6 +293,21 @@ module.exports = {
         },
       ]
     };
+    if (process.platform != 'darwin') {
+        view_menu.submenu.splice(2, 0, {
+            label: 'Toggle Menu Bar',
+            accelerator: 'Ctrl+Shift+M',
+            click: function(item, focusedWindow) {
+                if (focusedWindow.isMenuBarAutoHide()) {
+                    app.config.set('menu-bar', true);
+                    app.toggleMenuBar(focusedWindow);
+                } else {
+                    app.config.set('menu-bar', false);
+                    app.toggleMenuBar(focusedWindow);
+                }
+            }
+        });
+    }
 
     var go_menu = {
       label: 'Go',


### PR DESCRIPTION
This doesn't change the default behaviour, but allows Electron's auto-hiding menu bar support to be toggled on.