### PR TITLE
Switch the Quit accelerator to Ctrl+Q on non-Windows platforms.

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -203,7 +203,13 @@ module.exports = {
       });
       file_menu.submenu.push({
         label: 'Quit',
-        accelerator: 'Alt+F4',
+        accelerator: (function() {
+            if (process.platform == 'win32') {
+                return 'Alt+F4';
+            } else {
+                return 'Ctrl+Q';
+            }
+        })(),
         click: function(item, focusedWindow) {
           app.quit();
         }


### PR DESCRIPTION
This lines up better with other apps on non-Windows, non-Darwin platforms (ie Linux).