### PR TITLE
Add support for user stylesheets.

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -9,6 +9,7 @@ const Shell = electron.shell;
 const path = require('path');
 
 const ConfigStore = require('configstore');
+const FS = require('fs');
 const Menu = require('./menu');
 const Tray = require('tray');
 const SquirrelWindows = require('./squirrel_windows');
@@ -158,6 +159,16 @@ function openMainWindow() {
         ev.preventDefault();
         mainWindow.hide();
     }
+  });
+
+  mainWindow.webContents.on('dom-ready', function(event) {
+      FS.readFile('user-style.css', 'utf8', (err, data) => {
+          if (err) {
+              // That's OK; just means the file wasn't readable.
+              return;
+          }
+          mainWindow.webContents.insertCSS(data);
+      });
   });
 
 }


### PR DESCRIPTION
This is a total hack right now (it just loads a file called `user-style.css` if it exists in the working directory on startup), so my guess is that you won't want to merge this as-is, but I like to have the ability to tinker with the style of the IRCCloud interface. (I have been accused of being a typeface nerd.)

Is this something you'd be open to in a more generic cross-platform-friendly form, or is it just not something you're interested in?