### PR TITLE
Keep app running in background on app close (OSX)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -239,10 +239,16 @@ var quitting = false;
 app.on('before-quit', function () {
   quitting = true;
 });
-app.on('window-all-closed', function() {
-  app.quit();
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
 });
-
+app.on('activate', function () {
+  if (!mainWindow) {
+    openMainWindow();
+  }
+});
 // Handles urls from app.isDefaultProtocolClient
 app.on('open-url', function (event, url) {
   if (mainWindow) {


### PR DESCRIPTION
On OSX it's good practice to keep the app running in background even if the window is closed. It's the ideal behaviour on mac. Fixed - https://github.com/irccloud/irccloud-desktop/issues/56