### PR TITLE
Add RPM target to electron-builder.json

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -16,6 +16,7 @@
     "category": "Network;IRCClient",
     "target": [
       "deb",
+      "rpm",
       "AppImage"
     ]
   },


### PR DESCRIPTION
Relates to irccloud/irccloud-desktop/issues/122

Environment information and build results: [irccloud-desktop-rpm-build-results.txt](https://github.com/irccloud/irccloud-desktop/files/2388895/irccloud-desktop-rpm-build-results.txt)
