### PR TITLE
Set badge icon for unread channels

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -274,12 +274,23 @@ function openMainWindow(opts) {
   mainWindow.on('page-title-updated', function(event) {
     var title = mainWindow.getTitle();
     if (title && is.macOS()) {
-      var unread = "";
-      var matches = title.match(/^\((\d+)\)/);
+      var matches = title.match(/^(?:\((\d+)\)|([*+]))/);
+      var badge = "";
       if (matches) {
-        unread = matches[1];
+        if (matches[1]) {
+          badge = matches[1];
+        } else {
+          var current = app.dock.getBadge();
+          if (/^\d+$/.test(current)) badge = current;
+
+          // '+' means active channel has a notification
+          if (current === '+') badge = current;
+
+          // '*' means a channel has a notification
+          badge = matches[2];
+        }
       }
-      app.dock.setBadge(unread);
+      app.dock.setBadge(badge);
     }
   });
   


### PR DESCRIPTION
This updates the badge icon to include notifications for channels. I prioritized unread direct messages, then unread messages in the current channel (`+`), and finally unread messages in any channel (`*`).

It'd be better if it was possible to directly query the number of unread direct messages. Right now, if you have two active conversations, it's whichever title notification came last that will show in the unread count.