### PR TITLE
Remove --no-sandbox from Linux builds for better security

### DIFF
--- a/build/irccloud.desktop
+++ b/build/irccloud.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=IRCCloud
-Exec=/opt/IRCCloud/irccloud --no-sandbox %U
+Exec=/opt/IRCCloud/irccloud %U
 Terminal=false
 Type=Application
 Icon=irccloud

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -25,9 +25,7 @@
   },
   "linux": {
     "executableName": "irccloud",
-    "executableArgs": [
-      "--no-sandbox"
-    ],
+    "executableArgs": [ ],
     "category": "Network;IRCClient",
     "target": [
       "deb",


### PR DESCRIPTION
IRCCloud works fine without `--no-sandbox`, and adding it only serves to make things _less secure_. There was some discussion about Flatpak requiring `--no-sandbox`, but this is mostly worked out from the Flatpak side of things, and anyway, Flatpak-agers can add what they need. But shipping a normal .desktop file or a debian package with `--no-sandbox` is irresponsible and dangerous.